### PR TITLE
🔀 회원가입 페이지 warning 해결

### DIFF
--- a/src/shared/ui/Dropdown/index.tsx
+++ b/src/shared/ui/Dropdown/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { forwardRef, useEffect, useRef, useState } from 'react';
 
 import { ArrowDown, ArrowUp } from '@/shared/assets/icons';
 
@@ -11,7 +11,7 @@ interface Props {
   unit: string;
 }
 
-export default function Dropdown({ onChange, items, text, unit }: Props) {
+const Dropdown = forwardRef<HTMLDivElement, Props>(({ onChange, items, text, unit }, ref) => {
   const [isOpen, setIsOpen] = useState(false);
   const [selectedItem, setSelectedItem] = useState<number | string>(text);
   const dropdownRef = useRef<HTMLDivElement>(null);
@@ -74,4 +74,8 @@ export default function Dropdown({ onChange, items, text, unit }: Props) {
       )}
     </div>
   );
-}
+});
+
+Dropdown.displayName = 'Dropdown';
+
+export default Dropdown;

--- a/src/shared/ui/Input/index.tsx
+++ b/src/shared/ui/Input/index.tsx
@@ -16,10 +16,7 @@ const Input = forwardRef<HTMLInputElement, Props>(
       setIsPasswordVisible(prev => !prev);
     };
 
-    let inputType = type;
-    if (type === 'password') {
-      inputType = isPasswordVisible ? 'text' : 'password';
-    }
+    const inputType = type === 'password' && isPasswordVisible ? 'text' : type;
 
     const inputStyle = {
       WebkitBoxShadow: '0 0 0 30px white inset !important',
@@ -32,21 +29,18 @@ const Input = forwardRef<HTMLInputElement, Props>(
       }
     };
 
-    const inputId = `input-${Math.random().toString(36).substr(2, 9)}`;
-
     return (
       <div className="w-full">
         <div className="relative w-full rounded-md border-[3px] p-[16px] bg-white">
           <div className="w-full">
-            <label htmlFor={inputId} className="flex duration-200">
+            <label htmlFor={props.id} className="flex duration-200">
               <input
                 {...props}
-                id={inputId}
                 ref={ref}
                 type={inputType}
-                className="w-full text-gray-500 text-body2R "
+                className="w-full text-gray-500 text-body2R"
                 style={inputStyle}
-                placeholder={`${placeholder}`}
+                placeholder={placeholder}
                 onChange={handleChange}
                 value={value}
               />


### PR DESCRIPTION
## 💡 개요

sign-up 페이지에서 발생하던 warning의 원인을 발견하여 수정하였습니다
- Dropdown의 props 중 ref가 존재하지 않지만 Controller에서 ref를 전달하려고 시도하면서 warning 발생
- random 사용으로 인하여 id의 불일치 발생

#24 
#25 

## ✅ 확인해주세요

- Dropdown forwardRef 추가
- inputId 삭제
- Input 코드 정리

- [ ] 변경된 코드가 문서에 반영되었나요?
- [ ] 정상적으로 동작하나요?
- [ ] 병합하는 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
