### PR TITLE
🔀 useUser 훅 제작

### DIFF
--- a/src/app/api/auth/sign-in/route.ts
+++ b/src/app/api/auth/sign-in/route.ts
@@ -31,6 +31,18 @@ export async function POST(request: Request) {
       expires: refreshTokenExpires,
       sameSite: 'strict',
     });
+    const userResponse = await apiClient.get('/user', {
+      headers: { Authorization: `Bearer ${response.data.access_token}` },
+    });
+
+    const encodedUser = Buffer.from(JSON.stringify(userResponse.data)).toString('base64');
+
+    res.cookies.set('user', encodedUser, {
+      httpOnly: false,
+      secure: true,
+      expires: accessTokenExpires,
+      sameSite: 'strict',
+    });
 
     return res;
   } catch (error) {

--- a/src/app/api/user/route.ts
+++ b/src/app/api/user/route.ts
@@ -1,0 +1,19 @@
+import { AxiosError } from 'axios';
+import { NextResponse } from 'next/server';
+
+import { apiClient } from '@/shared/libs/apiClient';
+
+export async function GET() {
+  try {
+    const response = await apiClient.get('/user');
+    return NextResponse.json(response.data);
+  } catch (error) {
+    if (error instanceof AxiosError) {
+      return NextResponse.json(
+        { error: error.response?.data || 'Code verification failed' },
+        { status: error.response?.status || 500 }
+      );
+    }
+    return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
+  }
+}

--- a/src/entities/home/ui/ProfileContainer/index.tsx
+++ b/src/entities/home/ui/ProfileContainer/index.tsx
@@ -5,8 +5,8 @@ import userProfileImage from '@/shared/assets/jpg/userProfileImage.jpg';
 
 interface Props {
   src: string;
-  stuName: string;
-  stuNum: string;
+  stuName: string | undefined;
+  stuNum: number | undefined;
 }
 
 export default function ProfileContainer({ src, stuName, stuNum }: Props) {

--- a/src/shared/hooks/useUser.ts
+++ b/src/shared/hooks/useUser.ts
@@ -1,0 +1,48 @@
+import { useRouter } from 'next/navigation';
+import { useEffect } from 'react';
+import { toast } from 'react-toastify';
+
+import { useUserStore } from '../stores/useUserStore';
+
+export default function useUser() {
+  const { user, setUser } = useUserStore();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (user) {
+      return;
+    }
+
+    const cookies = document.cookie.split('; ').reduce(
+      (acc, cookie) => {
+        const [key, value] = cookie.split('=');
+        acc[key] = decodeURIComponent(value);
+        return acc;
+      },
+      {} as Record<string, string>
+    );
+
+    if (cookies.user) {
+      try {
+        const decodedString = atob(cookies.user);
+        const decodedUtf8String = new TextDecoder('utf-8').decode(
+          new Uint8Array([...decodedString].map(c => c.charCodeAt(0)))
+        );
+
+        const parsedUser = JSON.parse(decodedUtf8String);
+        const stuNum = Number(
+          `${parsedUser.student_info.grade}${parsedUser.student_info.classroom}${parsedUser.student_info.number.toString().padStart(2, '0')}`
+        );
+        setUser({ ...parsedUser, stuNum });
+      } catch (error) {
+        // router.push('/signin');
+        toast.error('유저 정보가 존재하지 않습니다');
+      }
+    } else {
+      // router.push('/signin');
+      toast.error('유저 정보가 존재하지 않습니다');
+    }
+  }, [setUser, user, router]);
+
+  return user;
+}

--- a/src/shared/stores/useUserStore.ts
+++ b/src/shared/stores/useUserStore.ts
@@ -1,0 +1,26 @@
+import { create } from 'zustand';
+
+interface User {
+  id: string;
+  name: string;
+  email: string;
+  gender: string;
+  student_info: {
+    isGraduate: boolean;
+    grade: number;
+    classroom: number;
+    number: number;
+    year: number;
+  };
+  stuNum?: number;
+}
+
+interface UserState {
+  user: User | null;
+  setUser: (user: User | null) => void;
+}
+
+export const useUserStore = create<UserState>(set => ({
+  user: null,
+  setUser: user => set({ user }),
+}));

--- a/src/widgets/home/ui/OverviewPanel/index.tsx
+++ b/src/widgets/home/ui/OverviewPanel/index.tsx
@@ -1,13 +1,15 @@
 import React from 'react';
 
 import { MealBoard, ProfileContainer, ScheduleBoard } from '@/entities/home';
+import useUser from '@/shared/hooks/useUser';
 
 export default function OverviewPanel() {
+  const user = useUser();
   return (
     <div className="w-full flex flex-1 gap-4 justify-center mobile:flex-col mobile:items-center">
       <ScheduleBoard />
       <MealBoard />
-      <ProfileContainer src="" stuName="민우석" stuNum="3308" />
+      <ProfileContainer src="" stuName={user?.name} stuNum={user?.stuNum} />
     </div>
   );
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "target": "es2015",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## 💡 개요
유저 정보 가져오기가 필요했다

- /user api를 get 하여 정보를 가져옵니다. 
쿠키에 저장하고, 쿠키에서 유저 정보를 디코딩해서
useUser 훅에서 사용자 정보를 사용할 수 있도록 구현했습니다. 
- 쿠키에 저장된 유저 정보를 디코딩하고, UTF-8로 변환한 후, JSON 형식으로 파싱하여 zustand의 userStore에 저장합니다. 
- 백엔드에서 학번을 안넘겨줘서 grade, classroom, number 값을 조합하여 프론트엔드에서 stuNum을 생성하는 로직을 추가했습니다. 



## ✅ 확인해주세요
훅에서는 쿠키에서 유저 정보를 가져오지 못했을 때, 로그인되지 않은 상태로 판단하고 /signin으로 리다이렉트하는 로직을 주석으로 달아두었는데
추후 로그인 판별 로직 추가 시 useUser 훅에서 에러 처리를 별도로 할 필요는 없을 것 같습니다.

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 변경된 코드가 문서에 반영되었나요?
- [x] 정상적으로 동작하나요?
- [x] 병합하는 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

