### PR TITLE
🔀 토큰 저장 안됨 해결

### DIFF
--- a/src/app/api/auth/sign-in/route.ts
+++ b/src/app/api/auth/sign-in/route.ts
@@ -20,17 +20,18 @@ export async function POST(request: Request) {
 
     res.cookies.set('accessToken', response.data.access_token, {
       httpOnly: true,
-      secure: true,
+      secure: process.env.NODE_ENV === 'production',
       expires: accessTokenExpires,
       sameSite: 'strict',
     });
 
     res.cookies.set('refreshToken', response.data.refresh_token, {
       httpOnly: true,
-      secure: true,
+      secure: process.env.NODE_ENV === 'production',
       expires: refreshTokenExpires,
       sameSite: 'strict',
     });
+
     const userResponse = await apiClient.get('/user', {
       headers: { Authorization: `Bearer ${response.data.access_token}` },
     });
@@ -39,7 +40,7 @@ export async function POST(request: Request) {
 
     res.cookies.set('user', encodedUser, {
       httpOnly: false,
-      secure: true,
+      secure: process.env.NODE_ENV === 'production',
       expires: accessTokenExpires,
       sameSite: 'strict',
     });


### PR DESCRIPTION
## 💡 개요
토큰이 쿠키에 저장이 안되는 오류를 해결했습니다.

> 어떤 문제가 발생한 이유와, 해결한 방법을 작성해주세요.

secure: true 옵션이 활성화되면 HTTPS 환경에서만 쿠키가 저장됩니다.
개발 환경에서 localhost를 사용할 경우 HTTPS가 적용되지 않아 쿠키가 저장되지 않는 문제가 발생했습니다.
개발 환경에서는 secure: false로 설정하여 로컬에서도 쿠키가 저장되도록 변경했습니다.

## ✅ 확인해주세요
- [x] 변경된 코드가 문서에 반영되었나요?
- [x] 정상적으로 동작하나요?
- [x] 병합하는 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

