### PR TITLE
🔀 수업 시간표 수업 탈출 오류 해결

### DIFF
--- a/src/entities/home/ui/ScheduleBoard/index.tsx
+++ b/src/entities/home/ui/ScheduleBoard/index.tsx
@@ -54,16 +54,29 @@ export default function ScheduleBoard() {
               </button>
             </div>
           </header>
-          <div className="flex flex-1 rounded-lg p-5 bg-gray-100 mobile:px-3 mobile:py-2">
+          <div className="w-full flex flex-1 rounded-lg p-5 bg-gray-100 mobile:px-3 mobile:py-2">
             {schedule ? (
-              <div className="flex flex-col flex-1 gap-4 mobile:gap-3">
+              <div className="w-full flex flex-col flex-1 gap-4 mobile:gap-3">
                 {schedule.map(item => (
                   <div
                     key={item.PERIO}
-                    className="flex items-center text-body3R gap-4 mobile:gap-3 mobile:text-caption1R"
+                    className="w-full h-[26px] flex items-center text-body3R gap-4 mobile:h-5 mobile:gap-3 mobile:text-caption1R"
                   >
-                    <span className="text-gray-500 text-caption2M">{item.PERIO}교시</span>{' '}
-                    <VerticalLine /> {item.ITRT_CNTNT}
+                    <span className="text-gray-500 text-body3R w-10 tablet:w-8 tablet:text-caption2M">
+                      {item.PERIO}교시
+                    </span>
+                    <VerticalLine />
+                    <span
+                      className="flex-1"
+                      style={{
+                        display: '-webkit-box',
+                        whiteSpace: 'nowrap',
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                      }}
+                    >
+                      {item.ITRT_CNTNT}
+                    </span>
                   </div>
                 ))}
               </div>


### PR DESCRIPTION
## 💡 개요

수업 이름이 보드보다 긴 경우 수업이 보드 바깥으로 나가는 오류가 생겼습니다.
이를 webkit-box로 감싸주어 해결하였습니다.

## ✅ 확인해주세요

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 변경된 코드가 문서에 반영되었나요?
- [x] 정상적으로 동작하나요?
- [x] 병합하는 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
