### PR TITLE
🔀 apply box progress bar의 z-index 수정 및 mobile footer z-index 추가

### DIFF
--- a/src/entities/home/ui/ApplyBoard/index.tsx
+++ b/src/entities/home/ui/ApplyBoard/index.tsx
@@ -55,7 +55,7 @@ export default function ApplyBoard({ title, count, maxCount, activationTime }: P
           <div className="flex justify-start w-full h-full relative">
             <div className="w-full bg-main-100 h-3 rounded-lg z-10" />
             <div
-              className="h-3 rounded-lg z-50 absolute"
+              className="h-3 rounded-lg"
               style={{
                 width: `calc(${(count / maxCount) * 100}%)`,
                 background: count !== maxCount ? `#AFBFF9` : `#1EB916`,

--- a/src/shared/ui/MobileFooter/index.tsx
+++ b/src/shared/ui/MobileFooter/index.tsx
@@ -23,7 +23,7 @@ export default function MobileFooter() {
 
   return (
     <div className="hidden mobile:block w-full ">
-      <div className="flex flex-col w-full max-w-[1360px] gap-9 text-caption2B text-gray-300  fixed bottom-0 bg-white">
+      <div className="flex flex-col w-full max-w-[1360px] gap-9 text-caption2B text-gray-300 z-50 fixed bottom-0 bg-white">
         <div className="flex justify-around px-4 py-2">
           {menuItems.map(({ icon: Icon, label, path }) => (
             <button


### PR DESCRIPTION
## 💡 개요

mobileFooter의 위로 progressbar가 나오는 오류가 있어 mobile Footer에 z-index를 추가하였습니다

## ✅ 확인해주세요

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 변경된 코드가 문서에 반영되었나요?
- [x] 정상적으로 동작하나요?
- [x] 병합하는 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
