### PR TITLE
🔀 자습 신청 취소 시 안마의자로 메시지가 뜨던 오류 해결

### DIFF
--- a/src/widgets/home/ui/DormitoryPanel/index.tsx
+++ b/src/widgets/home/ui/DormitoryPanel/index.tsx
@@ -60,7 +60,9 @@ function DormitoryPanel() {
           count={selfStudy?.current_count ?? 0}
           maxCount={selfStudy?.limit ?? 0}
           activationTime="20:00"
-          onClick={selfStudy?.status === 'APPLIED' ? () => deleteMassage() : () => postSelfStudy()}
+          onClick={
+            selfStudy?.status === 'APPLIED' ? () => deleteSelfStudy() : () => postSelfStudy()
+          }
           available={selfStudy?.status || 'IMPOSSIBLE'}
         />
         <ApplyBoard


### PR DESCRIPTION
## 💡 개요

자습 신청 취소 시 안마의자로 메시지가 뜨던 오류를 고쳤습니다.

#80

## ✅ 확인해주세요

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 변경된 코드가 문서에 반영되었나요?
- [ ] 정상적으로 동작하나요?
- [ ] 병합하는 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
