### PR TITLE
🔀 사유 글씨 제한 텍스트와 총 인원 텍스트가 겹치는 이슈 해결

### DIFF
--- a/src/entities/homebase/ui/StudentApplicationSection/index.tsx
+++ b/src/entities/homebase/ui/StudentApplicationSection/index.tsx
@@ -53,7 +53,7 @@ export default function StudentApplicationSection() {
         onChange={e => setReason(e.target.value)}
         value={reason || ''}
       />
-      <div className="flex gap-2 float-end mb-5 mt-2">
+      <div className="flex gap-2 float-end mb-5 mt-6">
         <p className="text-body2R text-gray-500">총 인원</p>
         <p className="text-body2B text-main-600">{selectedStudents.length}명</p>
       </div>


### PR DESCRIPTION
## 💡 개요
margin-bottom 조정하여 인풋 글자 겹침 해결하였습니다
> 어떤 문제가 발생한 이유와, 해결한 방법을 작성해주세요.

#88 