### PR TITLE
🔀 개발중 페이지 width 오류 해결

### DIFF
--- a/src/views/build/ui/index.tsx
+++ b/src/views/build/ui/index.tsx
@@ -5,8 +5,8 @@ import Tool from '@/shared/assets/icons/Tool';
 function Build() {
   return (
     <div
-      style={{ height: 'calc(100dvh - 180px)' }}
-      className="w-dvw flex justify-center items-center"
+      style={{ width: 'calc(100dvw-(100dvw-100%))', height: 'calc(100dvh - 180px)' }}
+      className="flex justify-center items-center"
     >
       <div className="flex flex-col items-center justify-center gap-[72px]">
         <Tool />


### PR DESCRIPTION
## 💡 개요

기존 개발중입니다 페이지의 width가 100dvw로 되어있어 스크롤바가 계산되지 않았습니다.
기존 100dvw를 calc(100dvw-(100dvw-100%))로 변경하여 스크롤바의 width를 제외한 값이 width로 사용되도록 수정했습니다.

#120 

## ✅ 확인해주세요

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 변경된 코드가 문서에 반영되었나요?
- [ ] 정상적으로 동작하나요?
- [ ] 병합하는 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
