### PR TITLE
🔀 refresh 에러 수정

### DIFF
--- a/src/app/api/auth/sign-in/route.ts
+++ b/src/app/api/auth/sign-in/route.ts
@@ -13,8 +13,12 @@ export async function POST(request: Request) {
   try {
     const response = await apiClient.post('/auth/sign-in', body);
 
-    const accessTokenExpires = new Date(`${response.data.access_token_expired_at}Z`);
-    const refreshTokenExpires = new Date(`${response.data.refresh_token_expired_at}Z`);
+    const accessTokenExpires = new Date(
+      new Date(`${response.data.access_token_expired_at}`).toUTCString()
+    );
+    const refreshTokenExpires = new Date(
+      new Date(`${response.data.refresh_token_expired_at}`).toUTCString()
+    );
 
     const res = NextResponse.json(response.data);
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,53 +1,62 @@
+import axios from 'axios';
 import { NextRequest, NextResponse } from 'next/server';
 
 export async function middleware(request: NextRequest) {
   const accessToken = request.cookies.get('accessToken')?.value;
   const refreshToken = request.cookies.get('refreshToken')?.value;
+  const user = request.cookies.get('user')?.value;
 
   if (!refreshToken) {
     return NextResponse.redirect(new URL('/signin', request.url));
   }
 
-  if (!accessToken) {
+  if (!accessToken || !user) {
     try {
-      const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/auth/re-issue`, {
-        method: 'PATCH',
-        headers: {
-          'Content-Type': 'application/json',
-          'Refresh-Token': `Bearer ${refreshToken}`,
-        },
-        credentials: 'include',
+      const res = await axios.patch(
+        `${process.env.NEXT_PUBLIC_BASE_URL}/auth/re-issue`,
+        {},
+        {
+          headers: {
+            'Content-Type': 'application/json',
+            'Refresh-Token': `Bearer ${refreshToken}`,
+          },
+        }
+      );
+
+      const userRes = await axios.get(`${process.env.NEXT_PUBLIC_BASE_URL}/user/myself`, {
+        headers: { Authorization: `Bearer ${res.data.access_token}` },
       });
 
-      if (!res.ok) {
-        return NextResponse.redirect(new URL('/signin', request.url));
-      }
-
-      const data = await res.json();
+      const encodedUser = Buffer.from(JSON.stringify(userRes.data)).toString('base64');
 
       const response = NextResponse.next();
 
-      response.cookies.set('accessToken', data.access_token, {
+      response.cookies.set('accessToken', res.data.access_token, {
         httpOnly: true,
         secure: process.env.NODE_ENV === 'production',
-        expires: new Date(`${data.access_token_expired_at}Z`),
+        expires: new Date(new Date(`${res.data.access_token_expired_at}`).toUTCString()),
         sameSite: 'strict',
       });
 
-      response.cookies.set('refreshToken', data.refresh_token, {
+      response.cookies.set('refreshToken', res.data.refresh_token, {
         httpOnly: true,
         secure: process.env.NODE_ENV === 'production',
-        expires: new Date(`${data.refresh_token_expired_at}Z`),
+        expires: new Date(new Date(`${res.data.refresh_token_expired_at}`).toUTCString()),
         sameSite: 'strict',
       });
 
+      response.cookies.set('user', encodedUser, {
+        httpOnly: false,
+        secure: process.env.NODE_ENV === 'production',
+        expires: new Date(new Date(`${res.data.access_token_expired_at}`).toUTCString()),
+        sameSite: 'strict',
+      });
       return response;
     } catch (err) {
       console.error('토큰 재발급 실패:', err);
       return NextResponse.redirect(new URL('/signin', request.url));
     }
   }
-
   return NextResponse.next();
 }
 


### PR DESCRIPTION
## 💡 개요

accessToken의 expire이 kst로 설정되어 실제 유효시간이 지난 후에도 남아있었습니다.
kst를 utc로 변환하여 저장하도록 수정했습니다.

#142 

## ✅ 확인해주세요

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 변경된 코드가 문서에 반영되었나요?
- [ ] 정상적으로 동작하나요?
- [ ] 병합하는 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
