### PR TITLE
🔀 신청 인원 정원 시 신청 취소 비활성화 해결

### DIFF
--- a/src/entities/home/model/checkApply.ts
+++ b/src/entities/home/model/checkApply.ts
@@ -6,7 +6,8 @@ interface Props {
   activationTime: string;
   available: ApplyType;
   setText: (type: string) => void;
-  setIsActive: (active: boolean) => void;
+  setIsTimeActive: (active: boolean) => void;
+  setIsCountFull: (active: boolean) => void;
 }
 
 const checkApply = ({
@@ -14,7 +15,8 @@ const checkApply = ({
   count,
   maxCount,
   available,
-  setIsActive,
+  setIsTimeActive,
+  setIsCountFull,
   setText,
 }: Props) => {
   const currentTime = new Intl.DateTimeFormat('kr', {
@@ -27,7 +29,8 @@ const checkApply = ({
   const isTimeActive = currentTime >= activationTime && currentTime < '21:00';
   const isCountFull = count === maxCount;
 
-  setIsActive(isTimeActive && !isCountFull);
+  setIsTimeActive(isTimeActive);
+  setIsCountFull(!isCountFull);
 
   if (available === 'POSSIBLE') {
     setText('신청하기');

--- a/src/entities/home/ui/ApplyBoard/index.tsx
+++ b/src/entities/home/ui/ApplyBoard/index.tsx
@@ -80,7 +80,7 @@ export default function ApplyBoard({
         </div>
         <Button
           text={text}
-          disabled={!isTimeActive || isCountFull || isPending}
+          disabled={!isTimeActive || (text !== '신청 취소' && isCountFull) || isPending}
           onClick={onClick}
           type="button"
           closed={text === '신청 불가'}

--- a/src/entities/home/ui/ApplyBoard/index.tsx
+++ b/src/entities/home/ui/ApplyBoard/index.tsx
@@ -28,7 +28,8 @@ export default function ApplyBoard({
   onClick,
   isPending,
 }: Props) {
-  const [isActive, setIsActive] = useState(false);
+  const [isTimeActive, setIsTimeActive] = useState(false);
+  const [isCountFull, setIsCountFull] = useState(false);
   const { setModal, setType } = useNotifyStore();
   const [text, setText] = useState('');
 
@@ -39,7 +40,15 @@ export default function ApplyBoard({
 
   useEffect(() => {
     const interval = setInterval(() => {
-      checkApply({ activationTime, available, count, maxCount, setIsActive, setText });
+      checkApply({
+        activationTime,
+        available,
+        count,
+        maxCount,
+        setIsTimeActive,
+        setIsCountFull,
+        setText,
+      });
     }, 1000);
 
     return () => clearInterval(interval);
@@ -71,7 +80,7 @@ export default function ApplyBoard({
         </div>
         <Button
           text={text}
-          disabled={!isActive || isPending}
+          disabled={!isTimeActive || isCountFull || isPending}
           onClick={onClick}
           type="button"
           closed={text === '신청 불가'}

--- a/src/widgets/dormitory/ui/massage/footer/index.tsx
+++ b/src/widgets/dormitory/ui/massage/footer/index.tsx
@@ -16,7 +16,8 @@ interface Props {
 }
 
 function MassageFooter({ count, maxCount, activationTime, available }: Props) {
-  const [isActive, setIsActive] = useState(false);
+  const [isTimeActive, setIsTimeActive] = useState(false);
+  const [isCountFull, setIsCountFull] = useState(false);
   const [text, setText] = useState('');
   const [modal, setModal] = useState(false);
   const { mutate: postMassage, isPending: postPending } = useDispatchMassage();
@@ -29,7 +30,15 @@ function MassageFooter({ count, maxCount, activationTime, available }: Props) {
 
   useEffect(() => {
     const interval = setInterval(() => {
-      checkApply({ activationTime, available, count, maxCount, setIsActive, setText });
+      checkApply({
+        activationTime,
+        available,
+        count,
+        maxCount,
+        setIsTimeActive,
+        setIsCountFull,
+        setText,
+      });
     }, 1000);
 
     return () => clearInterval(interval);
@@ -51,7 +60,7 @@ function MassageFooter({ count, maxCount, activationTime, available }: Props) {
             type="button"
             text={text}
             closed={text === '신청 불가'}
-            disabled={!isActive || deletePending || postPending}
+            disabled={!isTimeActive || isCountFull || deletePending || postPending}
             onClick={text === '신청 취소' ? () => setModal(true) : () => postMassage()}
           />
         </div>
@@ -62,7 +71,7 @@ function MassageFooter({ count, maxCount, activationTime, available }: Props) {
           description={
             '정말로 안마의자를 취소하시겠습니까?\n 안마의자 취소 후에는 재신청이 불가능합니다.'
           }
-          onClick={() => onConfirm()}
+          onClick={onConfirm}
           onClose={() => setModal(false)}
           title="안마의자 신청 취소"
         />

--- a/src/widgets/dormitory/ui/massage/footer/index.tsx
+++ b/src/widgets/dormitory/ui/massage/footer/index.tsx
@@ -60,7 +60,9 @@ function MassageFooter({ count, maxCount, activationTime, available }: Props) {
             type="button"
             text={text}
             closed={text === '신청 불가'}
-            disabled={!isTimeActive || isCountFull || deletePending || postPending}
+            disabled={
+              !isTimeActive || (text !== '신청 취소' && isCountFull) || deletePending || postPending
+            }
             onClick={text === '신청 취소' ? () => setModal(true) : () => postMassage()}
           />
         </div>

--- a/src/widgets/dormitory/ui/selfStudyBoard/footer/index.tsx
+++ b/src/widgets/dormitory/ui/selfStudyBoard/footer/index.tsx
@@ -22,7 +22,8 @@ function SelfStudyFooter({ activationTime, available, count, maxCount }: Props) 
   const { mutate: postSelfStudy, isPending: postPending } = useDispatchSelfStudy();
   const { mutate: deleteSelfStudy, isPending: deletePending } = useDeleteSelfStudy();
   const { check, setCheck } = useCheckStore();
-  const [isActive, setIsActive] = useState(false);
+  const [isTimeActive, setIsTimeActive] = useState(false);
+  const [isCountFull, setIsCountFull] = useState(false);
   const [text, setText] = useState('');
   const [modal, setModal] = useState(false);
   const dormitoryAdmin =
@@ -36,7 +37,15 @@ function SelfStudyFooter({ activationTime, available, count, maxCount }: Props) 
 
   useEffect(() => {
     const interval = setInterval(() => {
-      checkApply({ activationTime, available, count, maxCount, setIsActive, setText });
+      checkApply({
+        activationTime,
+        available,
+        count,
+        maxCount,
+        setIsTimeActive,
+        setIsCountFull,
+        setText,
+      });
     }, 1000);
 
     return () => clearInterval(interval);
@@ -69,7 +78,7 @@ function SelfStudyFooter({ activationTime, available, count, maxCount }: Props) 
             type="button"
             text={text}
             closed={text === '신청 불가'}
-            disabled={!isActive || deletePending || postPending}
+            disabled={!isTimeActive || isCountFull || deletePending || postPending}
             onClick={text === '신청 취소' ? () => setModal(true) : () => postSelfStudy()}
           />
         </div>

--- a/src/widgets/dormitory/ui/selfStudyBoard/footer/index.tsx
+++ b/src/widgets/dormitory/ui/selfStudyBoard/footer/index.tsx
@@ -78,7 +78,9 @@ function SelfStudyFooter({ activationTime, available, count, maxCount }: Props) 
             type="button"
             text={text}
             closed={text === '신청 불가'}
-            disabled={!isTimeActive || isCountFull || deletePending || postPending}
+            disabled={
+              !isTimeActive || (text !== '신청 취소' && isCountFull) || deletePending || postPending
+            }
             onClick={text === '신청 취소' ? () => setModal(true) : () => postSelfStudy()}
           />
         </div>


### PR DESCRIPTION
## 💡 개요

disable을 담당하던 `isActive`가  정원 달성 시 비활성화되는 `isCountFull`의 비교조건이 포함되어있어 발생한 에러를 `isActive` 분리로 해결했습니다

## ✅ 확인해주세요

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 변경된 코드가 문서에 반영되었나요?
- [ ] 정상적으로 동작하나요?
- [ ] 병합하는 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
